### PR TITLE
Document npm install workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Install dependencies:
 npm i
 ```
 
+If you encounter an error `No prebuilt binaries found`, try switching to node ` v18.17.0` (using [`n`](https://github.com/tj/n), for example) to work around our dependency's [build issue](https://github.com/WiseLibs/better-sqlite3/issues/1027).
+
 Then, navigate to the `circuits/` directory and install the dependencies there:
 
 ```bash


### PR DESCRIPTION
We depend on better-sqlite3@7.6.2, which has a build issue which can be worked around as described.

better-sqlite is not actually needed, it's just a transitive depedency: secp256k1_hash_to_curve_circom > circom-helper > better-sqlite3@7.6.2

The best solution is to edit secp256k1_hash_to_curve_circom so that we can import the circuits and typescript helpers without also importing the testing infrastructure, which better-sqlite3 is needed for. The workaround should be redundant once the dependencies are fixed.