### PR TITLE
TS implementation suggestion for #23

### DIFF
--- a/javascript/src/signals.ts
+++ b/javascript/src/signals.ts
@@ -40,7 +40,7 @@ export function computeC_V2(
     gPowRBytes,
     hashMPkPowRBytes,
   ]);
-  return createHash("sha256").update(preimage).digest("hex");
+  return hexToBigInt(createHash("sha256").update(preimage).digest("hex")) % CURVE.n;
 }
 
 export function computeC_V1(
@@ -66,7 +66,7 @@ export function computeC_V1(
     gPowRBytes,
     hashMPkPowRBytes,
   ]);
-  return createHash("sha256").update(preimage).digest("hex");
+  return hexToBigInt(createHash("sha256").update(preimage).digest("hex")) % CURVE.n;
 }
 
 export function computeNullifer(hashMPk: HashedPoint, secretKey: Uint8Array) {
@@ -81,8 +81,9 @@ export function computeHashMPkPowR(hashMPk: HashedPoint, r: Uint8Array) {
   return multiplyPoint(hashMPk, r);
 }
 
-export function computeS(r: Uint8Array, secretKey: Uint8Array, c: string) {
-  const skC = (uint8ArrayToBigInt(secretKey) * hexToBigInt(c)) % CURVE.n;
+export function computeS(r: Uint8Array, secretKey: Uint8Array, c: bigint) {
+  // TODO it's possible to accept both hexstring and bigint for `c` here
+  const skC = (uint8ArrayToBigInt(secretKey) * c) % CURVE.n;
   return ((skC + uint8ArrayToBigInt(r)) % CURVE.n).toString(16);
 }
 


### PR DESCRIPTION
This one could do #23 in TS part. I really need some approve that I got things correctly before moving on to Circom part.

Also pay attention to the note in the initial commit for this issue, pls. I suspect that Rust implementation actually should `panic` when SEC1 decoding gives number greq then the **field** order. 
_So the inconsistency might be much deeper._
* wrapping around field instead of curve order
* difference in decoding of the hash into an element 