### PR TITLE
Solve #63

### DIFF
--- a/rust-k256/src/lib.rs
+++ b/rust-k256/src/lib.rs
@@ -1,7 +1,6 @@
 // #![feature(generic_const_expr)]
 // #![allow(incomplete_features)]
 
-use std::panic;
 use elliptic_curve::bigint::ArrayEncoding;
 use elliptic_curve::hash2curve::{ExpandMsgXmd, GroupDigest};
 use elliptic_curve::ops::Reduce;
@@ -9,12 +8,9 @@ use elliptic_curve::sec1::ToEncodedPoint;
 use k256::{
     elliptic_curve::group::ff::PrimeField,
     sha2::{digest::Output, Digest, Sha256},
-    FieldBytes,
-    ProjectivePoint,
-    Scalar,
-    Secp256k1,
-    U256,
+    FieldBytes, ProjectivePoint, Scalar, Secp256k1, U256,
 }; // requires 'getrandom' feature
+use std::panic;
 
 const L: usize = 48;
 const COUNT: usize = 2;

--- a/rust-k256/src/lib.rs
+++ b/rust-k256/src/lib.rs
@@ -98,14 +98,16 @@ impl PlumeSignature<'_> {
     pub fn verify_signals(&self) -> bool {
         // don't forget to check `c` is `Output<Sha256>` in the #API
         let c = Output::<Sha256>::from_slice(self.c);
-        
+
         // TODO should we allow `c` input greater than BaseField::MODULUS?
         let c_scalar = panic::catch_unwind(|| {
             Scalar::from_uint_reduced(U256::from_be_byte_array(c.to_owned()))
         });
-        if c_scalar.is_err() {return false;}
+        if c_scalar.is_err() {
+            return false;
+        }
         let c_scalar = c_scalar.unwrap();
-        
+
         /* @skaunov would be glad to discuss with @Divide-By-0 excessiveness of the following check.
         Though I should notice that it at least doesn't breaking anything. */
         if c_scalar.is_zero().into() {
@@ -113,12 +115,14 @@ impl PlumeSignature<'_> {
         }
 
         let r_point = ProjectivePoint::GENERATOR * self.s - self.pk * &c_scalar;
-        
+
         let hashed_to_curve = hash_to_curve(self.message, self.pk);
-        if hashed_to_curve.is_err() {return false;}
+        if hashed_to_curve.is_err() {
+            return false;
+        }
         let hashed_to_curve = hashed_to_curve.unwrap();
-        
-        let hashed_to_curve_r = &hashed_to_curve * self.s - self.nullifier * &c_scalar;
+
+        let hashed_to_curve_r = hashed_to_curve * self.s - self.nullifier * &c_scalar;
 
         if let Some(PlumeSignatureV1Fields {
             r_point: sig_r_point,

--- a/rust-k256/src/lib.rs
+++ b/rust-k256/src/lib.rs
@@ -2,13 +2,11 @@
 // #![allow(incomplete_features)]
 
 use std::panic;
-
 use elliptic_curve::bigint::ArrayEncoding;
 use elliptic_curve::hash2curve::{ExpandMsgXmd, GroupDigest};
 use elliptic_curve::ops::Reduce;
 use elliptic_curve::sec1::ToEncodedPoint;
 use k256::{
-    // ecdsa::{signature::Signer, Signature, SigningKey},
     elliptic_curve::group::ff::PrimeField,
     sha2::{digest::Output, Digest, Sha256},
     FieldBytes,
@@ -30,7 +28,7 @@ fn print_type_of<T>(_: &T) {
 fn c_sha256_vec_signal(values: Vec<&ProjectivePoint>) -> Output<Sha256> {
     let preimage_vec = values
         .into_iter()
-        .map(|value| encode_pt(value))
+        .map(encode_pt)
         .collect::<Vec<_>>()
         .concat();
     let mut sha256_hasher = Sha256::new();


### PR DESCRIPTION
@Divide-By-0 look, it seems that it was intended that encoding function would check that the point being encoded isn't $(0:1:0)$, but the check was only imitated across the code without actual implementation. This one improves error-handling w.r.t. current implementation, *though it's the right moment to think about that check that isn't implemented.*

Previously I only added that check that `c` isn't zero. Now the question should the points get that check too? (Also technologically I don't think encoding function is the best place for it; I guess it could be typed.)