### PR TITLE
Move RustCrypto verifier into tests

### DIFF
--- a/rust-k256/src/lib.rs
+++ b/rust-k256/src/lib.rs
@@ -18,21 +18,13 @@
 //!     let sig_v1 = PlumeSignature::sign_v1(
 //!         &sk, b"ZK nullifier signature", &mut OsRng
 //!     );
-//!     assert!(sig_v1.verify());
 //!
 //!     let sig_v2 = PlumeSignature::sign_v2(
 //!         &sk, b"ZK nullifier signature", &mut OsRng
 //!     );
-//!     assert!(sig_v2.verify());
 //! # }
 //! ```
 
-use k256::elliptic_curve::bigint::ArrayEncoding;
-use k256::elliptic_curve::ops::Reduce;
-use k256::sha2::{digest::Output, Digest, Sha256}; // requires 'getrandom' feature
-use k256::ProjectivePoint;
-use k256::Scalar;
-use k256::U256;
 use signature::RandomizedSigner;
 
 /// Exports types from the `k256` crate:
@@ -49,9 +41,8 @@ pub use rand_core::CryptoRngCore;
 /// The `Serialize` and `Deserialize` traits from the Serde library are re-exported for convenience.
 pub use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
 mod utils;
-// not published due to use of `Projective...`; these utils can be found in other crates
-use utils::*;
 
 /// Provides the [`RandomizedSigner`] trait implementation over [`PlumeSignature`].
 pub mod randomizedsigner;
@@ -88,62 +79,6 @@ pub struct PlumeSignatureV1Fields {
     pub hashed_to_curve_r: AffinePoint,
 }
 impl PlumeSignature {
-    /// Verifies a PLUME signature.
-    /// Returns `true` if the signature is valid.
-    pub fn verify(&self) -> bool {
-        // Verifier check in SNARK:
-        // g^[r + sk * c] / (g^sk)^c = g^r
-        // hash[m, gsk]^[r + sk * c] / (hash[m, pk]^sk)^c = hash[m, pk]^r
-        // c = hash2(g, g^sk, hash[m, g^sk], hash[m, pk]^sk, gr, hash[m, pk]^r)
-
-        let c_scalar = *self.c;
-
-        let r_point = (ProjectivePoint::GENERATOR * *self.s) - (self.pk * (c_scalar));
-
-        let hashed_to_curve = hash_to_curve(&self.message, &self.pk.into());
-        if hashed_to_curve.is_err() {
-            return false;
-        }
-        let hashed_to_curve = hashed_to_curve.unwrap();
-
-        let hashed_to_curve_r = hashed_to_curve * *self.s - self.nullifier * (c_scalar);
-
-        if let Some(PlumeSignatureV1Fields {
-            r_point: sig_r_point,
-            hashed_to_curve_r: sig_hashed_to_curve_r,
-        }) = self.v1specific
-        {
-            // Check whether g^r equals g^s * pk^{-c}
-            if r_point != sig_r_point {
-                return false;
-            }
-
-            // Check whether h^r equals h^{r + sk * c} * nullifier^{-c}
-            if hashed_to_curve_r != sig_hashed_to_curve_r {
-                return false;
-            }
-
-            // Check if the given hash matches
-            c_scalar
-                == Scalar::reduce(U256::from_be_byte_array(c_sha256_vec_signal(vec![
-                    &ProjectivePoint::GENERATOR,
-                    &self.pk.into(),
-                    &hashed_to_curve,
-                    &self.nullifier.into(),
-                    &r_point,
-                    &hashed_to_curve_r,
-                ])))
-        } else {
-            // Check if the given hash matches
-            c_scalar
-                == Scalar::reduce(U256::from_be_byte_array(c_sha256_vec_signal(vec![
-                    &self.nullifier.into(),
-                    &r_point,
-                    &hashed_to_curve_r,
-                ])))
-        }
-    }
-
     /// Yields the signature with `None` for `v1specific`. Same as using [`RandomizedSigner`] with [`PlumeSigner`];
     /// use it when you don't want to `use` PlumeSigner and the trait in your code.
     pub fn sign_v1(secret_key: &SecretKey, msg: &[u8], rng: &mut impl CryptoRngCore) -> Self {
@@ -156,21 +91,11 @@ impl PlumeSignature {
     }
 }
 
-fn c_sha256_vec_signal(values: Vec<&ProjectivePoint>) -> Output<Sha256> {
-    let preimage_vec = values
-        .into_iter()
-        .map(encode_pt)
-        .collect::<Vec<_>>()
-        .concat();
-    let mut sha256_hasher = Sha256::new();
-    sha256_hasher.update(preimage_vec.as_slice());
-    sha256_hasher.finalize()
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::utils::encode_pt;
     use hex_literal::hex;
+    use k256::{ProjectivePoint, Scalar};
 
     // Test encode_pt()
     #[test]

--- a/rust-k256/src/randomizedsigner.rs
+++ b/rust-k256/src/randomizedsigner.rs
@@ -1,7 +1,4 @@
-use super::{
-    CryptoRngCore, NonZeroScalar, PlumeSignature, PlumeSignatureV1Fields, ProjectivePoint,
-    SecretKey, DST,
-};
+use super::{CryptoRngCore, NonZeroScalar, PlumeSignature, PlumeSignatureV1Fields, SecretKey, DST};
 use k256::{
     elliptic_curve::{
         hash2curve::{ExpandMsgXmd, GroupDigest},
@@ -9,7 +6,7 @@ use k256::{
         sec1::ToEncodedPoint,
     },
     sha2::{Digest, Sha256},
-    Secp256k1,
+    ProjectivePoint, Secp256k1,
 };
 // Removed `pub` from this, since it's only interested to those who already imported `signature`
 use signature::{Error, RandomizedSigner};
@@ -35,7 +32,7 @@ pub struct PlumeSigner<'signing> {
 impl<'signing> PlumeSigner<'signing> {
     /// Creates a new `PlumeSigner` instance with the given secret key and signature
     /// variant.
-    pub fn new(secret_key: &SecretKey, v1: bool) -> PlumeSigner {
+    pub fn new(secret_key: &SecretKey, v1: bool) -> PlumeSigner<'_> {
         PlumeSigner { secret_key, v1 }
     }
 }

--- a/rust-k256/src/utils.rs
+++ b/rust-k256/src/utils.rs
@@ -1,23 +1,4 @@
-use super::*;
-use k256::{
-    elliptic_curve::{
-        hash2curve::{ExpandMsgXmd, GroupDigest},
-        sec1::ToEncodedPoint,
-    },
-    ProjectivePoint, Secp256k1,
-}; // requires 'getrandom' feature
-
-// Hashes two values to the curve
-pub(crate) fn hash_to_curve(
-    m: &[u8],
-    pk: &ProjectivePoint,
-) -> Result<ProjectivePoint, k256::elliptic_curve::Error> {
-    Secp256k1::hash_from_bytes::<ExpandMsgXmd<Sha256>>(
-        &[[m, &encode_pt(pk)].concat().as_slice()],
-        //b"CURVE_XMD:SHA-256_SSWU_RO_",
-        &[DST],
-    )
-}
+use k256::{elliptic_curve::sec1::ToEncodedPoint, ProjectivePoint};
 
 /// Encodes the point by compressing it to 33 bytes
 pub(crate) fn encode_pt(point: &ProjectivePoint) -> Vec<u8> {

--- a/rust-k256/tests/verification.rs
+++ b/rust-k256/tests/verification.rs
@@ -3,8 +3,17 @@
 //! Their setup is shared, `mod helpers` contains barely not refactored code, which is still instrumental to the tests.
 
 use helpers::{gen_test_scalar_sk, test_gen_signals, PlumeVersion};
-use k256::{elliptic_curve::sec1::ToEncodedPoint, NonZeroScalar, ProjectivePoint};
-use plume_rustcrypto::{AffinePoint, PlumeSignature, PlumeSignatureV1Fields};
+use k256::{
+    elliptic_curve::{
+        bigint::ArrayEncoding,
+        hash2curve::{ExpandMsgXmd, GroupDigest},
+        ops::Reduce,
+        sec1::ToEncodedPoint,
+    },
+    sha2::{digest::Output, Digest, Sha256},
+    NonZeroScalar, ProjectivePoint, Scalar, Secp256k1, U256,
+};
+use plume_rustcrypto::{PlumeSignature, PlumeSignatureV1Fields};
 
 const G: ProjectivePoint = ProjectivePoint::GENERATOR;
 const M: &[u8; 29] = b"An example app message string";
@@ -42,7 +51,7 @@ fn plume_v1_test() {
             hashed_to_curve_r: hashed_to_curve_r.into(),
         }),
     };
-    let verified = sig.verify();
+    let verified = verify_signature(&sig);
     println!("Verified: {}", verified);
 
     // Print nullifier
@@ -95,15 +104,85 @@ fn plume_v1_test() {
 #[test]
 fn plume_v2_test() {
     let test_data = test_gen_signals(M, PlumeVersion::V2);
-    assert!(PlumeSignature {
+    let sig = PlumeSignature {
         message: M.to_owned().into(),
         pk: (G * gen_test_scalar_sk()).into(),
         nullifier: test_data.1.into(),
         c: NonZeroScalar::from_repr(test_data.2).unwrap(),
         s: NonZeroScalar::new(test_data.3).unwrap(),
-        v1specific: None
+        v1specific: None,
+    };
+
+    assert!(verify_signature(&sig));
+}
+
+fn verify_signature(sig: &PlumeSignature) -> bool {
+    let c_scalar = *sig.c;
+
+    let r_point = (ProjectivePoint::GENERATOR * *sig.s) - (sig.pk * c_scalar);
+
+    let hashed_to_curve = match hash_to_curve(&sig.message, &sig.pk.into()) {
+        Ok(point) => point,
+        Err(_) => return false,
+    };
+
+    let hashed_to_curve_r = hashed_to_curve * *sig.s - sig.nullifier * c_scalar;
+
+    if let Some(PlumeSignatureV1Fields {
+        r_point: sig_r_point,
+        hashed_to_curve_r: sig_hashed_to_curve_r,
+    }) = &sig.v1specific
+    {
+        if r_point != *sig_r_point {
+            return false;
+        }
+
+        if hashed_to_curve_r != *sig_hashed_to_curve_r {
+            return false;
+        }
+
+        c_scalar
+            == Scalar::reduce(U256::from_be_byte_array(c_sha256_vec_signal(vec![
+                &ProjectivePoint::GENERATOR,
+                &sig.pk.into(),
+                &hashed_to_curve,
+                &sig.nullifier.into(),
+                &r_point,
+                &hashed_to_curve_r,
+            ])))
+    } else {
+        c_scalar
+            == Scalar::reduce(U256::from_be_byte_array(c_sha256_vec_signal(vec![
+                &sig.nullifier.into(),
+                &r_point,
+                &hashed_to_curve_r,
+            ])))
     }
-    .verify());
+}
+
+fn hash_to_curve(
+    m: &[u8],
+    pk: &ProjectivePoint,
+) -> Result<ProjectivePoint, k256::elliptic_curve::Error> {
+    Secp256k1::hash_from_bytes::<ExpandMsgXmd<Sha256>>(
+        &[[m, &encode_pt(pk)].concat().as_slice()],
+        &[plume_rustcrypto::DST],
+    )
+}
+
+fn encode_pt(point: &ProjectivePoint) -> Vec<u8> {
+    point.to_encoded_point(true).to_bytes().to_vec()
+}
+
+fn c_sha256_vec_signal(values: Vec<&ProjectivePoint>) -> Output<Sha256> {
+    let preimage_vec = values
+        .into_iter()
+        .map(encode_pt)
+        .collect::<Vec<_>>()
+        .concat();
+    let mut sha256_hasher = Sha256::new();
+    sha256_hasher.update(preimage_vec.as_slice());
+    sha256_hasher.finalize()
 }
 
 mod helpers {
@@ -113,13 +192,11 @@ mod helpers {
     use hex_literal::hex;
     use k256::{
         elliptic_curve::{
-            bigint::ArrayEncoding,
             hash2curve::{ExpandMsgXmd, GroupDigest},
-            ops::ReduceNonZero,
             PrimeField,
         },
         sha2::{digest::Output, Digest, Sha256},
-        Scalar, Secp256k1, U256,
+        Scalar, Secp256k1,
     };
 
     #[derive(Debug)]


### PR DESCRIPTION
Fixes #112.

Summary:
- remove `PlumeSignature::verify` from the RustCrypto public API and doctest example
- keep equivalent verification logic private to `rust-k256/tests/verification.rs`
- keep the point encoding utility compiled only for crate tests

Tests:
- `cargo test -p plume_rustcrypto`

Note: the remaining warnings are pre-existing in `rust-k256/tests/signing.rs`.