### PR TITLE
Reject noncanonical arkworks digest scalars

### DIFF
--- a/rust-arkworks/src/lib.rs
+++ b/rust-arkworks/src/lib.rs
@@ -162,6 +162,23 @@ fn compute_c_v2(
     Sha256::digest(c_preimage_vec.as_slice())
 }
 
+const SECP256K1_SCALAR_ORDER_BYTES: [u8; 32] = [
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xfe, 0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e, 0x8c, 0xd0, 0x36,
+    0x41, 0x41,
+];
+
+fn digest_to_nonzero_scalar(bytes: &[u8]) -> Option<Fr> {
+    if bytes.len() != SECP256K1_SCALAR_ORDER_BYTES.len()
+        || bytes.iter().all(|byte| *byte == 0)
+        || bytes >= SECP256K1_SCALAR_ORDER_BYTES.as_slice()
+    {
+        return None;
+    }
+
+    Some(secp256k1::Fr::from_be_bytes_mod_order(bytes))
+}
+
 /// A struct containing parameters for the SW model, including the generator point `g_point`.
 /// This struct implements traits for (de)serialization.
 #[derive(
@@ -254,7 +271,11 @@ pub fn sign_with_r(
         ),
         PlumeVersion::V2 => compute_c_v2(&nullifier, &r_point, &hashed_to_curve_r),
     };
-    let c_scalar = secp256k1::Fr::from_be_bytes_mod_order(c.as_ref());
+    let c_scalar = digest_to_nonzero_scalar(c.as_ref()).ok_or_else(|| {
+        HashToCurveError::MapToCurveError(
+            "SHA-256 digest must be a non-zero canonical secp256k1 scalar".into(),
+        )
+    })?;
     // Compute s = r + sk ⋅ c
     let sk_c = keypair.1 * &c_scalar;
     let s = r_scalar + sk_c;

--- a/rust-arkworks/src/tests.rs
+++ b/rust-arkworks/src/tests.rs
@@ -49,7 +49,10 @@ pub fn verify_non_zk(
             super::compute_c_v2(&sig.0.nullifier, &sig.1.r_point, &sig.1.hashed_to_curve_r)
         }
     };
-    let c_scalar = secp256k1::Fr::from_be_bytes_mod_order(c.as_ref());
+    let c_scalar = match super::digest_to_nonzero_scalar(c.as_ref()) {
+        Some(c_scalar) => c_scalar,
+        None => return Ok(false),
+    };
 
     // Reject if g^s ⋅ pk^{-c} != g^r
     let g_s = pp.g_point.mul(sig.0.s);
@@ -313,4 +316,18 @@ fn test_point_sec1_encoding() {
             hex::decode(vector.1.as_bytes()).unwrap()
         );
     }
+}
+
+#[test]
+fn test_digest_to_nonzero_scalar_rejects_non_canonical_values() {
+    let mut below_order = super::SECP256K1_SCALAR_ORDER_BYTES;
+    below_order[31] -= 1;
+    assert!(super::digest_to_nonzero_scalar(&below_order).is_some());
+
+    assert!(super::digest_to_nonzero_scalar(&[0u8; 32]).is_none());
+    assert!(super::digest_to_nonzero_scalar(&super::SECP256K1_SCALAR_ORDER_BYTES).is_none());
+
+    let mut above_order = super::SECP256K1_SCALAR_ORDER_BYTES;
+    above_order[31] += 1;
+    assert!(super::digest_to_nonzero_scalar(&above_order).is_none());
 }


### PR DESCRIPTION
## Summary
- reject SHA-256 digest bytes that are zero or greater than/equal to the secp256k1 scalar order before converting them to `Fr`
- make the arkworks verifier treat the same non-canonical digest case as invalid instead of reducing modulo the order
- add a regression test for below-order, zero, order, and above-order digest values

## Bounty
Resolves #149. The repository README says GitHub issues are eligible for the $50 Eth/DAI bounty.

## Test plan
- `git diff --check`

## Notes
- Local Rust verification was blocked because this Windows environment does not have `cargo` or `rustc` installed. GitHub CI should run the workspace Rust checks.